### PR TITLE
Add margin between icons and titles on homepage

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -284,7 +284,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
   <div class="rightfeature">
     <h4><i class="fas fa-terminal fa-fw"></i>
-       &nbspExecute Kubectl commands
+       &nbsp   Execute Kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.
@@ -346,7 +346,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
   <div class="rightfeature">
     <h4><i class="fab fa-github"> </i>
-      &nbsp &nbsp  Open source
+      &nbsp &nbspOpen source
     </h4>
     BotKube backend is open source and we welcome your requirements and contributions.
   </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -167,6 +167,16 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     overflow: auto;
     display: block;
   }
+  .leftfeature{
+    i{
+	padding-right:10px;
+	}	
+   }
+  .rightfeature{
+    i{
+	padding-right:10px;
+	}	
+   }
 }
 
 </style>
@@ -309,7 +319,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4><i class="fas fa-cogs fa-fw"></i>
-     &nbsp &nbsp  Debug Anywhere, Anytime
+     Debug Anywhere, Anytime
     </h4>
     With @BotKube you can monitor and debug Kubernetes deployments from anywhere.
     Even while you are camping without a laptop, you can use Slack, Mattermost or MS Teams mobile app and get crucial information.

--- a/content/_index.md
+++ b/content/_index.md
@@ -284,7 +284,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-terminal fa-fw"> </i>
-            Execute kubectl commands
+      &nbsp Execute kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.

--- a/content/_index.md
+++ b/content/_index.md
@@ -284,7 +284,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
   <div class="rightfeature">
     <h4><i class="fas fa-terminal fa-fw"></i>
-       Execute Kubectl commands
+       &nbspExecute Kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.

--- a/content/_index.md
+++ b/content/_index.md
@@ -284,7 +284,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
   <div class="rightfeature">
     <h4><i class="fas fa-terminal fa-fw"></i>
-       &nbsp   Execute Kubectl commands
+        Execute Kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.
@@ -340,13 +340,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4> <i class="fas fa-shield-alt fa-fw"> </i>
-      &nbsp &nbsp Security
+      &nbsp Security
     </h4>
     By default BotKube uses a READONLY service account, you can customize this to your needs.
   </div>
   <div class="rightfeature">
     <h4><i class="fab fa-github"> </i>
-      &nbsp &nbspOpen source
+      &nbsp Open source
     </h4>
     BotKube backend is open source and we welcome your requirements and contributions.
   </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -200,7 +200,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     <div class="righttitle">
       <a href="https://github.com/kubeshop/botkube" class="linkhighlight">
         <i class="fab fa-github"></i>
-        View Source Code
+        View Source
       </a>
     </div>
   </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -194,7 +194,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     <div class="lefttitle">
       <a href="/installation" class="linkhighlight">
         <i class="fas fa-rocket"></i>
-        Try Now!
+        Try Now !
       </a>
     </div>
     <div class="righttitle">
@@ -278,7 +278,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4><i class="fas fa-fw fa-user-secret fa-fw"></i>
-      &nbsp Privacy
+       &nbsp Privacy
     </h4>
     The backend for the BotKube app runs in your Kubernetes cluster - thus you have complete control on your data and software.
   </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -325,7 +325,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4> <i class="fas fa-cloud fa-fw"> </i>
-      &nbsp &nbsp  Deploy on any Kubernetes cluster
+      &nbsp Deploy on any Kubernetes cluster
     </h4>
     You can deploy BotKube backend on any Kubernetes cluster, whether it is Minikube or cloud managed Kubernetes or anything in between.
   </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -284,7 +284,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     The backend for the BotKube app runs in your Kubernetes cluster - thus you have complete control on your data and software.
   </div>
   <div class="rightfeature">
-    <h4><i style="padding-right:10px;" class="fas fa-terminal fa-fw"></i>
+    <h4><i style="margin-right:10px;" class="fas fa-terminal fa-fw"></i>
         Execute Kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
@@ -294,7 +294,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i style="padding-right:10px;" class="fas fa-tasks fa-fw"> </i>
+    <h4> <i style="margin-right:8px;" class="fas fa-tasks fa-fw"> </i>
        Support for multiple interfaces
     </h4>
     Like Slack, BotKube can also be integrated with Mattermost, Microsoft Teams, ElasticSearch and outgoing webhook. See <a href=/configuration>configuration</a> syntax for details.
@@ -309,14 +309,14 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4><i style="padding-right:10px;" class="fas fa-cogs fa-fw"></i>
+    <h4><i style="margin-right:10px;" class="fas fa-cogs fa-fw"></i>
      Debug Anywhere, Anytime
     </h4>
     With @BotKube you can monitor and debug Kubernetes deployments from anywhere.
     Even while you are camping without a laptop, you can use Slack, Mattermost or MS Teams mobile app and get crucial information.
   </div>
   <div class="rightfeature">
-    <h4> <i style="padding-right:10px;" class="fas fa-cogs fa-fw"> </i>
+    <h4> <i style="margin-right:10px;" class="fas fa-cogs fa-fw"> </i>
 	 Easy to configure
     </h4>
     Get notifications about things that you really care for. You can configure events or objects or namespaces that you want to be informed about.
@@ -325,7 +325,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i style="padding-right:10px;" class="fas fa-cloud fa-fw"> </i>
+    <h4> <i style="margin-right:10px;" class="fas fa-cloud fa-fw"> </i>
        Deploy on any Kubernetes cluster
     </h4>
     You can deploy BotKube backend on any Kubernetes cluster, whether it is Minikube or cloud managed Kubernetes or anything in between.

--- a/content/_index.md
+++ b/content/_index.md
@@ -167,7 +167,14 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     overflow: auto;
     display: block;
   }
- 
+	
+  .features {
+  text-align: center;
+  }	
+	
+  .features h4 > i {
+    margin-right: 10px
+  }
 }
 
 </style>
@@ -274,18 +281,18 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
 </div>
 
-<center>
+<div class="features">
 <h2>Features</h2>
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4><i style="padding-right:10px;" class="fas fa-fw fa-user-secret fa-fw"></i>
-       Privacy
+    <h4><i class="fas fa-fw fa-user-secret fa-fw"></i>
+      Privacy
     </h4>
     The backend for the BotKube app runs in your Kubernetes cluster - thus you have complete control on your data and software.
   </div>
   <div class="rightfeature">
-    <h4><i style="margin-right:10px;" class="fas fa-terminal fa-fw"></i>
-        Execute Kubectl commands
+    <h4><i class="fas fa-terminal fa-fw"></i>
+      Execute Kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.
@@ -294,14 +301,14 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i style="margin-right:8px;" class="fas fa-tasks fa-fw"> </i>
-       Support for multiple interfaces
+    <h4> <i class="fas fa-tasks fa-fw"> </i>
+      Support for multiple interfaces
     </h4>
     Like Slack, BotKube can also be integrated with Mattermost, Microsoft Teams, ElasticSearch and outgoing webhook. See <a href=/configuration>configuration</a> syntax for details.
   </div>
   <div class="rightfeature">
-    <h4> <i style="padding-right:10px;" class="fas fa-puzzle-piece"></i>
-        Supports Custom Resources
+    <h4> <i class="fas fa-puzzle-piece"></i>
+      Supports Custom Resources
     </h4>
     BotKube can monitor literally any Kubernetes resource including Custom Resource. This enables you to configure alerts on some interesting events like - certificate issue/expiry if you are using cert-manager or backup failure in case you are using backup tools like Velero or Kanister.
   </div>
@@ -309,15 +316,15 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4><i style="margin-right:10px;" class="fas fa-cogs fa-fw"></i>
-     Debug Anywhere, Anytime
+    <h4><i class="fas fa-cogs fa-fw"></i>
+      Debug Anywhere, Anytime
     </h4>
     With @BotKube you can monitor and debug Kubernetes deployments from anywhere.
     Even while you are camping without a laptop, you can use Slack, Mattermost or MS Teams mobile app and get crucial information.
   </div>
   <div class="rightfeature">
-    <h4> <i style="margin-right:10px;" class="fas fa-cogs fa-fw"> </i>
-	 Easy to configure
+    <h4> <i class="fas fa-cogs fa-fw"> </i>
+      Easy to configure
     </h4>
     Get notifications about things that you really care for. You can configure events or objects or namespaces that you want to be informed about.
   </div>
@@ -325,13 +332,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i style="margin-right:10px;" class="fas fa-cloud fa-fw"> </i>
-       Deploy on any Kubernetes cluster
+    <h4> <i class="fas fa-cloud fa-fw"> </i>
+      Deploy on any Kubernetes cluster
     </h4>
     You can deploy BotKube backend on any Kubernetes cluster, whether it is Minikube or cloud managed Kubernetes or anything in between.
   </div>
   <div class="rightfeature">
-    <h4> <i style="padding-right:10px;" class="fas fa-plug fa-fw"> </i>
+    <h4> <i class="fas fa-plug fa-fw"> </i>
       Add custom filters
     </h4>
     It is very easy to write your own filters and registering them to FilterEngine. Follow <a href=/filters>this</a> guide to know more.
@@ -340,20 +347,20 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i style="padding-right:10px;" class="fas fa-shield-alt fa-fw"> </i>
-       Security
+    <h4> <i class="fas fa-shield-alt fa-fw"> </i>
+      Security
     </h4>
     By default BotKube uses a READONLY service account, you can customize this to your needs.
   </div>
   <div class="rightfeature">
-    <h4><i style="padding-right:10px;" class="fab fa-github"> </i>
+    <h4><i class="fab fa-github"> </i>
       Open source
     </h4>
     BotKube backend is open source and we welcome your requirements and contributions.
   </div>
 </div>
-
-</center>
+	
+</div>
 
 <hr>
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -283,8 +283,8 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     The backend for the BotKube app runs in your Kubernetes cluster - thus you have complete control on your data and software.
   </div>
   <div class="rightfeature">
-    <h4> <i class="fas fa-terminal fa-fw"> </i>
-      &nbsp Execute kubectl commands
+    <h4><i class="fas fa-fw fa-user-secret fa-fw"></i>
+       Execute Kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.

--- a/content/_index.md
+++ b/content/_index.md
@@ -292,7 +292,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
   <div class="rightfeature">
     <h4><i class="fas fa-terminal fa-fw"></i>
-      Execute <code>kubectl</code> commands
+      Execute kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.

--- a/content/_index.md
+++ b/content/_index.md
@@ -194,7 +194,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     <div class="lefttitle">
       <a href="/installation" class="linkhighlight">
         <i class="fas fa-rocket"></i>
-        Try Now !
+        Try Now!
       </a>
     </div>
     <div class="righttitle">
@@ -278,13 +278,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4><i class="fas fa-fw fa-user-secret fa-fw"></i>
-       &nbsp Privacy
+       Privacy
     </h4>
     The backend for the BotKube app runs in your Kubernetes cluster - thus you have complete control on your data and software.
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-terminal fa-fw"> </i>
-      &nbsp &nbsp  Execute kubectl commands
+      &nbsp  Execute kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.
@@ -300,7 +300,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-puzzle-piece"></i>
-       &nbsp &nbsp  Supports Custom Resources
+       &nbsp  Supports Custom Resources
     </h4>
     BotKube can monitor literally any Kubernetes resource including Custom Resource. This enables you to configure alerts on some interesting events like - certificate issue/expiry if you are using cert-manager or backup failure in case you are using backup tools like Velero or Kanister.
   </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -294,13 +294,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4> <i class="fas fa-tasks fa-fw"> </i>
-      &nbsp Support for multiple interfaces
+       Support for multiple interfaces
     </h4>
     Like Slack, BotKube can also be integrated with Mattermost, Microsoft Teams, ElasticSearch and outgoing webhook. See <a href=/configuration>configuration</a> syntax for details.
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-puzzle-piece"></i>
-       &nbsp  Supports Custom Resources
+        Supports Custom Resources
     </h4>
     BotKube can monitor literally any Kubernetes resource including Custom Resource. This enables you to configure alerts on some interesting events like - certificate issue/expiry if you are using cert-manager or backup failure in case you are using backup tools like Velero or Kanister.
   </div>
@@ -316,7 +316,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-cogs fa-fw"> </i>
-	&nbsp &nbsp  Easy to configure
+	 Easy to configure
     </h4>
     Get notifications about things that you really care for. You can configure events or objects or namespaces that you want to be informed about.
   </div>
@@ -325,13 +325,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4> <i class="fas fa-cloud fa-fw"> </i>
-      &nbsp Deploy on any Kubernetes cluster
+       Deploy on any Kubernetes cluster
     </h4>
     You can deploy BotKube backend on any Kubernetes cluster, whether it is Minikube or cloud managed Kubernetes or anything in between.
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-plug fa-fw"> </i>
-      &nbsp  Add custom filters
+      Add custom filters
     </h4>
     It is very easy to write your own filters and registering them to FilterEngine. Follow <a href=/filters>this</a> guide to know more.
   </div>
@@ -340,13 +340,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4> <i class="fas fa-shield-alt fa-fw"> </i>
-      &nbsp Security
+       Security
     </h4>
     By default BotKube uses a READONLY service account, you can customize this to your needs.
   </div>
   <div class="rightfeature">
     <h4><i class="fab fa-github"> </i>
-      &nbsp Open source
+      Open source
     </h4>
     BotKube backend is open source and we welcome your requirements and contributions.
   </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -283,7 +283,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     The backend for the BotKube app runs in your Kubernetes cluster - thus you have complete control on your data and software.
   </div>
   <div class="rightfeature">
-    <h4><i class="fas fa-fw fa-user-secret fa-fw"></i>
+    <h4><i class="fas fa-terminal fa-fw"></i>
        Execute Kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!

--- a/content/_index.md
+++ b/content/_index.md
@@ -167,16 +167,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     overflow: auto;
     display: block;
   }
-  .leftfeature{
-    i{
-	padding-right:10px;
-	}	
-   }
-  .rightfeature{
-    i{
-	padding-right:10px;
-	}	
-   }
+ 
 }
 
 </style>
@@ -287,13 +278,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <h2>Features</h2>
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4><i class="fas fa-fw fa-user-secret fa-fw"></i>
+    <h4><i style="padding-right:10px;" class="fas fa-fw fa-user-secret fa-fw"></i>
        Privacy
     </h4>
     The backend for the BotKube app runs in your Kubernetes cluster - thus you have complete control on your data and software.
   </div>
   <div class="rightfeature">
-    <h4><i class="fas fa-terminal fa-fw"></i>
+    <h4><i style="padding-right:10px;" class="fas fa-terminal fa-fw"></i>
         Execute Kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
@@ -303,13 +294,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i class="fas fa-tasks fa-fw"> </i>
+    <h4> <i style="padding-right:10px;" class="fas fa-tasks fa-fw"> </i>
        Support for multiple interfaces
     </h4>
     Like Slack, BotKube can also be integrated with Mattermost, Microsoft Teams, ElasticSearch and outgoing webhook. See <a href=/configuration>configuration</a> syntax for details.
   </div>
   <div class="rightfeature">
-    <h4> <i class="fas fa-puzzle-piece"></i>
+    <h4> <i style="padding-right:10px;" class="fas fa-puzzle-piece"></i>
         Supports Custom Resources
     </h4>
     BotKube can monitor literally any Kubernetes resource including Custom Resource. This enables you to configure alerts on some interesting events like - certificate issue/expiry if you are using cert-manager or backup failure in case you are using backup tools like Velero or Kanister.
@@ -318,14 +309,14 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4><i class="fas fa-cogs fa-fw"></i>
+    <h4><i style="padding-right:10px;" class="fas fa-cogs fa-fw"></i>
      Debug Anywhere, Anytime
     </h4>
     With @BotKube you can monitor and debug Kubernetes deployments from anywhere.
     Even while you are camping without a laptop, you can use Slack, Mattermost or MS Teams mobile app and get crucial information.
   </div>
   <div class="rightfeature">
-    <h4> <i class="fas fa-cogs fa-fw"> </i>
+    <h4> <i style="padding-right:10px;" class="fas fa-cogs fa-fw"> </i>
 	 Easy to configure
     </h4>
     Get notifications about things that you really care for. You can configure events or objects or namespaces that you want to be informed about.
@@ -334,13 +325,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i class="fas fa-cloud fa-fw"> </i>
+    <h4> <i style="padding-right:10px;" class="fas fa-cloud fa-fw"> </i>
        Deploy on any Kubernetes cluster
     </h4>
     You can deploy BotKube backend on any Kubernetes cluster, whether it is Minikube or cloud managed Kubernetes or anything in between.
   </div>
   <div class="rightfeature">
-    <h4> <i class="fas fa-plug fa-fw"> </i>
+    <h4> <i style="padding-right:10px;" class="fas fa-plug fa-fw"> </i>
       Add custom filters
     </h4>
     It is very easy to write your own filters and registering them to FilterEngine. Follow <a href=/filters>this</a> guide to know more.
@@ -349,13 +340,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i class="fas fa-shield-alt fa-fw"> </i>
+    <h4> <i style="padding-right:10px;" class="fas fa-shield-alt fa-fw"> </i>
        Security
     </h4>
     By default BotKube uses a READONLY service account, you can customize this to your needs.
   </div>
   <div class="rightfeature">
-    <h4><i class="fab fa-github"> </i>
+    <h4><i style="padding-right:10px;" class="fab fa-github"> </i>
       Open source
     </h4>
     BotKube backend is open source and we welcome your requirements and contributions.

--- a/content/_index.md
+++ b/content/_index.md
@@ -194,7 +194,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     <div class="lefttitle">
       <a href="/installation" class="linkhighlight">
         <i class="fas fa-rocket"></i>
-        Try Now !
+        Try Now!
       </a>
     </div>
     <div class="righttitle">

--- a/content/_index.md
+++ b/content/_index.md
@@ -194,7 +194,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     <div class="lefttitle">
       <a href="/installation" class="linkhighlight">
         <i class="fas fa-rocket"></i>
-        Try Now!
+        Try Now !
       </a>
     </div>
     <div class="righttitle">
@@ -284,7 +284,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-terminal fa-fw"> </i>
-      &nbsp  Execute kubectl commands
+            Execute kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.

--- a/content/_index.md
+++ b/content/_index.md
@@ -194,13 +194,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     <div class="lefttitle">
       <a href="/installation" class="linkhighlight">
         <i class="fas fa-rocket"></i>
-        Try Now
+        Try Now!
       </a>
     </div>
     <div class="righttitle">
       <a href="https://github.com/kubeshop/botkube" class="linkhighlight">
         <i class="fab fa-github"></i>
-        View Source
+        View Source Code
       </a>
     </div>
   </div>
@@ -278,13 +278,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4><i class="fas fa-fw fa-user-secret fa-fw"></i>
-      Privacy
+      &nbsp Privacy
     </h4>
     The backend for the BotKube app runs in your Kubernetes cluster - thus you have complete control on your data and software.
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-terminal fa-fw"> </i>
-      Execute kubectl commands
+      &nbsp &nbsp  Execute kubectl commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.
@@ -294,13 +294,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4> <i class="fas fa-tasks fa-fw"> </i>
-      Support for multiple interfaces
+      &nbsp &nbsp  Support for multiple interfaces
     </h4>
     Like Slack, BotKube can also be integrated with Mattermost, Microsoft Teams, ElasticSearch and outgoing webhook. See <a href=/configuration>configuration</a> syntax for details.
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-puzzle-piece"></i>
-      Supports Custom Resources
+       &nbsp &nbsp  Supports Custom Resources
     </h4>
     BotKube can monitor literally any Kubernetes resource including Custom Resource. This enables you to configure alerts on some interesting events like - certificate issue/expiry if you are using cert-manager or backup failure in case you are using backup tools like Velero or Kanister.
   </div>
@@ -309,14 +309,14 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4><i class="fas fa-cogs fa-fw"></i>
-      Debug Anywhere, Anytime
+     &nbsp &nbsp  Debug Anywhere, Anytime
     </h4>
     With @BotKube you can monitor and debug Kubernetes deployments from anywhere.
     Even while you are camping without a laptop, you can use Slack, Mattermost or MS Teams mobile app and get crucial information.
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-cogs fa-fw"> </i>
-	Easy to configure
+	&nbsp &nbsp  Easy to configure
     </h4>
     Get notifications about things that you really care for. You can configure events or objects or namespaces that you want to be informed about.
   </div>
@@ -325,13 +325,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4> <i class="fas fa-cloud fa-fw"> </i>
-      Deploy on any Kubernetes cluster
+      &nbsp &nbsp  Deploy on any Kubernetes cluster
     </h4>
     You can deploy BotKube backend on any Kubernetes cluster, whether it is Minikube or cloud managed Kubernetes or anything in between.
   </div>
   <div class="rightfeature">
     <h4> <i class="fas fa-plug fa-fw"> </i>
-      Add custom filters
+      &nbsp  Add custom filters
     </h4>
     It is very easy to write your own filters and registering them to FilterEngine. Follow <a href=/filters>this</a> guide to know more.
   </div>
@@ -340,13 +340,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4> <i class="fas fa-shield-alt fa-fw"> </i>
-      Security
+      &nbsp &nbsp Security
     </h4>
     By default BotKube uses a READONLY service account, you can customize this to your needs.
   </div>
   <div class="rightfeature">
     <h4><i class="fab fa-github"> </i>
-      Open source
+      &nbsp &nbsp  Open source
     </h4>
     BotKube backend is open source and we welcome your requirements and contributions.
   </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -83,6 +83,14 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 .lefttitle i, .righttitle i {
   padding: 0 5px;
 }
+	
+.features {
+  text-align: center;
+  }	
+	
+ .features h4 > i {
+    margin-right: 10px;
+  }	
 
 .lefttitle:hover, .righttitle:hover {
   background-color: #1C90F3;
@@ -168,13 +176,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     display: block;
   }
 	
-  .features {
-  text-align: center;
-  }	
-	
-  .features h4 > i {
-    margin-right: 10px
-  }
+  
 }
 
 </style>
@@ -301,13 +303,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i class="fas fa-tasks fa-fw"> </i>
+    <h4><i class="fas fa-tasks fa-fw"></i>
       Support for multiple interfaces
     </h4>
     Like Slack, BotKube can also be integrated with Mattermost, Microsoft Teams, ElasticSearch and outgoing webhook. See <a href=/configuration>configuration</a> syntax for details.
   </div>
   <div class="rightfeature">
-    <h4> <i class="fas fa-puzzle-piece"></i>
+    <h4><i class="fas fa-puzzle-piece"></i>
       Supports Custom Resources
     </h4>
     BotKube can monitor literally any Kubernetes resource including Custom Resource. This enables you to configure alerts on some interesting events like - certificate issue/expiry if you are using cert-manager or backup failure in case you are using backup tools like Velero or Kanister.
@@ -323,7 +325,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     Even while you are camping without a laptop, you can use Slack, Mattermost or MS Teams mobile app and get crucial information.
   </div>
   <div class="rightfeature">
-    <h4> <i class="fas fa-cogs fa-fw"> </i>
+    <h4><i class="fas fa-cogs fa-fw"></i>
       Easy to configure
     </h4>
     Get notifications about things that you really care for. You can configure events or objects or namespaces that you want to be informed about.
@@ -332,13 +334,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i class="fas fa-cloud fa-fw"> </i>
+    <h4><i class="fas fa-cloud fa-fw"></i>
       Deploy on any Kubernetes cluster
     </h4>
     You can deploy BotKube backend on any Kubernetes cluster, whether it is Minikube or cloud managed Kubernetes or anything in between.
   </div>
   <div class="rightfeature">
-    <h4> <i class="fas fa-plug fa-fw"> </i>
+    <h4><i class="fas fa-plug fa-fw"></i>
       Add custom filters
     </h4>
     It is very easy to write your own filters and registering them to FilterEngine. Follow <a href=/filters>this</a> guide to know more.
@@ -347,13 +349,13 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 
 <div style="overflow: auto;">
   <div class="leftfeature">
-    <h4> <i class="fas fa-shield-alt fa-fw"> </i>
+    <h4><i class="fas fa-shield-alt fa-fw"></i>
       Security
     </h4>
     By default BotKube uses a READONLY service account, you can customize this to your needs.
   </div>
   <div class="rightfeature">
-    <h4><i class="fab fa-github"> </i>
+    <h4><i class="fab fa-github"></i>
       Open source
     </h4>
     BotKube backend is open source and we welcome your requirements and contributions.

--- a/content/_index.md
+++ b/content/_index.md
@@ -294,7 +294,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 <div style="overflow: auto;">
   <div class="leftfeature">
     <h4> <i class="fas fa-tasks fa-fw"> </i>
-      &nbsp &nbsp  Support for multiple interfaces
+      &nbsp Support for multiple interfaces
     </h4>
     Like Slack, BotKube can also be integrated with Mattermost, Microsoft Teams, ElasticSearch and outgoing webhook. See <a href=/configuration>configuration</a> syntax for details.
   </div>

--- a/content/_index.md
+++ b/content/_index.md
@@ -86,11 +86,11 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
 	
 .features {
   text-align: center;
-  }	
-	
- .features h4 > i {
-    margin-right: 10px;
-  }	
+}	
+
+.features h4 > i {
+  margin-right: 10px;
+}	
 
 .lefttitle:hover, .righttitle:hover {
   background-color: #1C90F3;
@@ -175,8 +175,6 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     overflow: auto;
     display: block;
   }
-	
-  
 }
 
 </style>
@@ -294,7 +292,7 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
   </div>
   <div class="rightfeature">
     <h4><i class="fas fa-terminal fa-fw"></i>
-      Execute Kubectl commands
+      Execute <code>kubectl</code> commands
     </h4>
     Same old Kubectl syntax - just a new interface. You do not have to learn anything new!
     Plus you can configure which Kubectl commands BotKube can executes. See <a href=/configuration>configuration</a> for details.
@@ -361,7 +359,6 @@ a.linkhighlight:hover:after, a.linkhighlight:focus:after {
     BotKube backend is open source and we welcome your requirements and contributions.
   </div>
 </div>
-	
 </div>
 
 <hr>


### PR DESCRIPTION
The titles with their respective logo looks  so awkward that the logo and the titles are very closely spaced. A non-breaking space would do good. Also adding an emotion to make viewers try the app can be made by placing "!" mark after try now. Instead of simply "view source",   "View Source Code" would be clear enough for the visitors out there.