### PR TITLE
Update uninstall commands for Slack

### DIFF
--- a/content/installation/Slack/_index.md
+++ b/content/installation/Slack/_index.md
@@ -174,9 +174,22 @@ $ kubectl create -f deploy-all-in-one.yaml
 
 If you have installed BotKube backend using **helm**, execute following command to completely remove BotKube and related resources from your cluster.
 
+{{< tabs >}}
+{{% tab name="Helm 3" %}}
+
 ```bash
-$ helm delete --purge botkube
+$ helm uninstall botkube --namespace botkube
 ```
+
+{{% /tab %}}
+{{% tab name="Helm 2" %}}
+
+```bash
+$ helm delete --purge botkube --namespace botkube
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 #### Using kubectl
 


### PR DESCRIPTION
in Helm 3, there's no `--purge` option and it will fail to run. In both Helm 2 and 3, passing the `--namespace` option is required. Since the default namespace for botkube is `botkube` (according to the install command above), I kept it here.