### PR TITLE
Update Helm chart uninstall command

### DIFF
--- a/content/installation/Discord/_index.md
+++ b/content/installation/Discord/_index.md
@@ -213,7 +213,7 @@ Follow the first 4 mins of this [Video Tutorial](https://youtu.be/8o25pRbXdFw) t
 If you have installed BotKube backend using **helm**, execute following command to completely remove BotKube and related resources from your cluster.
 
 ```bash
-$ helm delete --purge botkube
+$ helm uninstall botkube
 ```
 
 #### Using kubectl

--- a/content/installation/ElasticSearch/_index.md
+++ b/content/installation/ElasticSearch/_index.md
@@ -133,7 +133,7 @@ toc = true
 If you have installed BotKube backend using **helm**, execute following command to completely remove BotKube and related resources from your cluster
 
 ```bash
-$ helm delete --purge botkube
+$ helm uninstall botkube
 ```
 
 #### Using kubectl

--- a/content/installation/Mattermost/_index.md
+++ b/content/installation/Mattermost/_index.md
@@ -207,7 +207,7 @@ Add BotKube user created to the channel you want to receive notifications in.
 If you have installed BotKube backend using **helm**, execute following command to completely remove BotKube and related resources from your cluster
 
 ```bash
-$ helm delete --purge botkube
+$ helm uninstall botkube
 ```
 
 #### Using kubectl

--- a/content/installation/Slack/_index.md
+++ b/content/installation/Slack/_index.md
@@ -155,7 +155,7 @@ After installing BotKube app to your Slack workspace, you could see a new bot us
 If you have installed BotKube backend using **helm**, execute following command to completely remove BotKube and related resources from your cluster.
 
 ```bash
-$ helm delete --purge botkube
+$ helm uninstall botkube
 ```
 
 #### Using kubectl

--- a/content/installation/Teams/_index.md
+++ b/content/installation/Teams/_index.md
@@ -263,7 +263,7 @@ If you get 404, please check the ingress configuration or endpoint you configure
 If you have installed BotKube backend using **helm**, execute the following command to completely remove BotKube and related resources from your cluster.
 
 ```bash
-$ helm delete --purge botkube
+$ helm uninstall botkube
 ```
 
 #### Using kubectl

--- a/content/installation/Webhook/_index.md
+++ b/content/installation/Webhook/_index.md
@@ -122,7 +122,7 @@ BotKube can be integrated with external apps via Webhooks. A webhook is essentia
 If you have installed BotKube backend using **helm**, execute following command to completely remove BotKube and related resources from your cluster
 
 ```bash
-$ helm delete --purge botkube
+$ helm uninstall botkube
 ```
 
 #### Using kubectl


### PR DESCRIPTION
This PR update Helm chart uninstall command, as observed in https://github.com/kubeshop/botkube-docs/pull/61.

While `helm delete` still works (as this is one of the aliases), I went with the main command name (`uninstall`).