### PR TITLE
Rename https://www.botkube.io to https://botkube.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![BotKube logo](/static/images/botkube-title.jpg)
 
-For complete documentation visit www.botkube.io
+For complete documentation visit [https://botkube.io](https://botkube.io)
 
 A slack bot which keeps eye on your Kubernetes resources and notifies
 about resources life cycles events, errors and warnings. It allows you

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://www.botkube.io/"
+baseURL = "https://botkube.io/"
 languageCode = "en-us"
 title = "Messaging bot for monitoring and debugging Kubernetes clusters"
 theme = "hugo-theme-learn"
@@ -14,7 +14,7 @@ home = [ "HTML", "RSS", "JSON"]
   github = "https://github.com/kubeshop/botkube" # add your github profile name
   email = "frontdesk@kubeshop.io"
   description = "BotKube is a messaging bot for monitoring and debugging Kubernetes clusters."
-  images = ['https://www.botkube.io/images/botkube_multicluster_v2.svg']
+  images = ['https://botkube.io/images/botkube_multicluster_v2.svg']
   showVisitedLinks = false
   disableBreadcrumb = false
   disableNextPrev = false

--- a/content/configuration/helm-options.md
+++ b/content/configuration/helm-options.md
@@ -7,7 +7,7 @@ weight: 40
 
 Controller for the BotKube Slack app which helps you monitor your Kubernetes cluster, debug deployments and run specific checks on resources in the cluster.
 
-**Homepage:** <https://www.botkube.io>
+**Homepage:** <https://botkube.io>
 
 ## Maintainers
 

--- a/content/contribute/_index.md
+++ b/content/contribute/_index.md
@@ -11,7 +11,7 @@ We'd love your help!
 
 BotKube is [MIT Licensed](/LICENSE) and accepts contributions via GitHub pull requests. This document outlines some of the conventions on development workflow, commit message formatting, contact points and other resources to make it easier to get your contributions accepted.
 
-We gratefully welcome improvements to [documentation](https://www.botkube.io/ "Go to documentation site") as well as to code.
+We gratefully welcome improvements to [documentation](https://botkube.io/ "Go to documentation site") as well as to code.
 
 ## Contributing to documentation
 

--- a/content/contribute/_index.md
+++ b/content/contribute/_index.md
@@ -45,8 +45,6 @@ Now you can build and run BotKube by one of the following ways
 
 2. Deploy newly created image in your cluster.
 
-   a. Using Helm v3
-
    ```sh
    kubectl create namespace botkube
    helm install --version v9.99.9-dev botkube --namespace botkube \

--- a/content/installation/Discord/_index.md
+++ b/content/installation/Discord/_index.md
@@ -24,7 +24,7 @@ Follow the steps below to install BotKube Discord app to your Discord server.
 
     ![discord_copy_client_id](/images/discord_copy_application_id.png)
 
-    Add a description - `BotKube is a messaging bot for monitoring and debugging Kubernetes clusters. Visit https://www.botkube.io/usage for help.`.
+    Add a description - `BotKube is a messaging bot for monitoring and debugging Kubernetes clusters. Visit https://botkube.io/usage for help.`.
 
     Set the BotKube icon (BotKube icon can be downloaded from [this link](https://github.com/kubeshop/botkube/raw/main/branding/logos/botkube_192x192.png)).
 


### PR DESCRIPTION
## Changes

- Rename https://www.botkube.io to https://botkube.io
  - Fix the search functionality
  - Ensure consistency

The Hugo `baseURL` is set with `www`, and even though we have a proper redirect it's still blocked:
```
Access to XMLHttpRequest at 'https://www.botkube.io/index.json' from origin 'https://botkube.io' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

