### PR TITLE
Fix invalid discord param

### DIFF
--- a/content/installation/Discord/_index.md
+++ b/content/installation/Discord/_index.md
@@ -97,7 +97,7 @@ Follow the first 4 mins of this [Video Tutorial](https://youtu.be/8o25pRbXdFw) t
   $ helm install --version v0.12.4 botkube --namespace botkube --create-namespace \
   --set communications.discord.enabled=true \
   --set communications.discord.channel=<DISCORD_CHANNEL_ID> \
-  --set communications.discord.botID=<DISCORD_BOT_ID> \
+  --set communications.discord.botid=<DISCORD_BOT_ID> \
   --set communications.discord.token=<DISCORD_TOKEN> \
   --set config.settings.clustername=<CLUSTER_NAME> \
   --set config.settings.kubectl.enabled=<ALLOW_KUBECTL> \


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Misleading parameter `--set communications.discord.botID` is updated as `--set communications.discord.botid` for Discord botkube installation since this is the correct usage for `v0.12.*`. Once we released `v0.13.*`, we should revert this back.

## Related issue(s)
Fixes #126 

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
