### PR TITLE
Update webhook docs for v0.13 release

### DIFF
--- a/content/installation/Webhook/_index.md
+++ b/content/installation/Webhook/_index.md
@@ -22,11 +22,13 @@ BotKube can be integrated with external apps via Webhooks. A webhook is essentia
 - Deploy BotKube backend using **helm install** in your cluster:
 
   ```bash
+  $ export CLUSTER_NAME={cluster_name}
+  $ export WEBHOOK_URL={url}
+  
   $ helm install --version v0.13.0 botkube --namespace botkube --create-namespace \
   --set communications.default-group.webhook.enabled=true \
-  --set communications.default-group.webhook.url=<WEBHOOK_URL> \
-  --set config.settings.clustername=<CLUSTER_NAME> \
-  --set image.tag=v0.13.0 \
+  --set communications.default-group.webhook.url=${WEBHOOK_URL} \
+  --set config.settings.clusterName=${CLUSTER_NAME} \
   botkube/botkube
   ```
 

--- a/content/installation/Webhook/_index.md
+++ b/content/installation/Webhook/_index.md
@@ -28,7 +28,7 @@ BotKube can be integrated with external apps via Webhooks. A webhook is essentia
   $ helm install --version v0.13.0 botkube --namespace botkube --create-namespace \
   --set communications.default-group.webhook.enabled=true \
   --set communications.default-group.webhook.url=${WEBHOOK_URL} \
-  --set config.settings.clusterName=${CLUSTER_NAME} \
+  --set settings.clusterName=${CLUSTER_NAME} \
   botkube/botkube
   ```
 

--- a/content/installation/Webhook/_index.md
+++ b/content/installation/Webhook/_index.md
@@ -22,11 +22,11 @@ BotKube can be integrated with external apps via Webhooks. A webhook is essentia
 - Deploy BotKube backend using **helm install** in your cluster:
 
   ```bash
-  $ helm install --version v0.12.4 botkube --namespace botkube --create-namespace \
-  --set communications.webhook.enabled=true \
-  --set communications.webhook.url=<WEBHOOK_URL> \
+  $ helm install --version v0.13.0 botkube --namespace botkube --create-namespace \
+  --set communications.default-group.webhook.enabled=true \
+  --set communications.default-group.webhook.url=<WEBHOOK_URL> \
   --set config.settings.clustername=<CLUSTER_NAME> \
-  --set image.tag=v0.12.4 \
+  --set image.tag=v0.13.0 \
   botkube/botkube
   ```
 
@@ -44,7 +44,7 @@ BotKube can be integrated with external apps via Webhooks. A webhook is essentia
   2. Pass the YAML file as a flag to `helm install` command, e.g.:
 
       ```
-      helm install --version v0.12.4 --name botkube --namespace botkube --create-namespace -f /path/to/config.yaml --set=...other args..
+      helm install --version v0.13.0 --name botkube --namespace botkube --create-namespace -f /path/to/config.yaml --set=...other args..
       ```
 
   Alternatively, you can also update the configuration at runtime as documented [here](/configuration/#updating-the-configuration-at-runtime)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Helm chart version is updated as `v0.13.0`
- webhooks params now is under `default-group` by default.

## Related issue(s)

- https://github.com/kubeshop/botkube/issues/595
