### PR TITLE
Add redirection to support old links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,7 +3,7 @@
 const path = require("path");
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
-const { createRedirects } = require("./redirects");
+const { createRedirects, redirects } = require("./redirects");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -78,6 +78,7 @@ const config = {
       "@docusaurus/plugin-client-redirects",
       {
         createRedirects,
+        redirects,
       },
     ],
     path.resolve(__dirname, "src", "plugins", "contributors"),

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,6 +3,7 @@
 const path = require("path");
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
+const { createRedirects } = require("./redirects");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -71,6 +72,12 @@ const config = {
         min: 500,
         steps: 4,
         disableInDev: false,
+      },
+    ],
+    [
+      "@docusaurus/plugin-client-redirects",
+      {
+        createRedirects,
       },
     ],
     path.resolve(__dirname, "src", "plugins", "contributors"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,10 @@
   "packages": {
     "": {
       "name": "docusaurus-website",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@docusaurus/core": "2.0.1",
+        "@docusaurus/plugin-client-redirects": "2.0.1",
         "@docusaurus/plugin-google-gtag": "^2.0.1",
         "@docusaurus/plugin-ideal-image": "^2.0.1",
         "@docusaurus/preset-classic": "2.0.1",
@@ -2190,6 +2191,29 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.0.1.tgz",
+      "integrity": "sha512-A/giM3MIRRyUmxNzLb/jWvmRf0NtPYX4bV04njAnziAdPo4dqT4dZF2Hvy0uUSaF/SXPGLUjrZWWpzTl5mTJtQ==",
+      "dependencies": {
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
+        "eta": "^1.12.3",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
@@ -15253,6 +15277,22 @@
         "@types/react-router-dom": "*",
         "react-helmet-async": "*",
         "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      }
+    },
+    "@docusaurus/plugin-client-redirects": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.0.1.tgz",
+      "integrity": "sha512-A/giM3MIRRyUmxNzLb/jWvmRf0NtPYX4bV04njAnziAdPo4dqT4dZF2Hvy0uUSaF/SXPGLUjrZWWpzTl5mTJtQ==",
+      "requires": {
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
+        "eta": "^1.12.3",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-content-blog": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.1",
+    "@docusaurus/plugin-client-redirects": "2.0.1",
     "@docusaurus/plugin-google-gtag": "^2.0.1",
     "@docusaurus/plugin-ideal-image": "^2.0.1",
     "@docusaurus/preset-classic": "2.0.1",

--- a/redirects.js
+++ b/redirects.js
@@ -26,7 +26,7 @@ function getVersions() {
  * @param {string} path
  * @return boolean
  */
-function haVersionInPath(path) {
+function hasVersionInPath(path) {
   const versions = getVersions();
 
   return versions.some(ver => path.includes(ver));
@@ -37,7 +37,7 @@ function haVersionInPath(path) {
  * @return {string[]|undefined}
  */
 function createRedirects(existingPath) {
-  if (!haVersionInPath(existingPath)) {
+  if (!hasVersionInPath(existingPath)) {
     for (const subPath of subPathsToRedirect) {
       if (existingPath.includes(subPath)) {
         return [existingPath.replace(subPath, "")];
@@ -48,6 +48,23 @@ function createRedirects(existingPath) {
   return undefined;
 }
 
+/**
+ * @return {{to: string, from: string}[]}
+ */
+function customRedirections() {
+  return [
+    {
+      to: "/docs/installation/",
+      from: "/docs",
+    },
+    {
+      to: "/community/contribute/",
+      from: "/community",
+    },
+  ];
+}
+
 module.exports = {
+  redirects: customRedirections(),
   createRedirects,
 };

--- a/redirects.js
+++ b/redirects.js
@@ -1,0 +1,53 @@
+// We need to maintain custom redirects as it's not handled automatically by Docusaurus: https://github.com/facebook/docusaurus/issues/3407
+// NOTE: Redirects don't work in development mode. Use `npm run build` and `npm run serve` to see them in action.
+//
+// https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-client-redirects
+const fs = require("fs");
+const subPathsToRedirect = ["/docs", "/community"];
+let versions;
+
+/**
+ * @return {string[]}
+ */
+function getVersions() {
+  if (!Array.isArray(versions)) {
+    try {
+      versions = JSON.parse(String(fs.readFileSync("./versions.json")));
+      versions.push("next");
+    } catch {
+      versions = ["next"];
+    }
+  }
+
+  return versions;
+}
+
+/**
+ * @param {string} path
+ * @return boolean
+ */
+function haVersionInPath(path) {
+  const versions = getVersions();
+
+  return versions.some(ver => path.includes(ver));
+}
+
+/**
+ * @param {string} existingPath
+ * @return {string[]|undefined}
+ */
+function createRedirects(existingPath) {
+  if (!haVersionInPath(existingPath)) {
+    for (const subPath of subPathsToRedirect) {
+      if (existingPath.includes(subPath)) {
+        return [existingPath.replace(subPath, "")];
+      }
+    }
+  }
+
+  return undefined;
+}
+
+module.exports = {
+  createRedirects,
+};


### PR DESCRIPTION
## Description
- make redirection to support old links (Hugo structure)

## Related issue(s)
Not created in project

## Preview

https://363ac78f.botkube-docs-c3c.pages.dev/

## How to test

Try old links like:
https://363ac78f.botkube-docs-c3c.pages.dev/installation/
https://363ac78f.botkube-docs-c3c.pages.dev/configuration/
https://363ac78f.botkube-docs-c3c.pages.dev/contribute/
etc ...
and it should redirect you to the corresponding page in latest version.
