### PR TITLE
Support kubectl aliases

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -16,8 +16,16 @@ By default, kubectl command execution is disabled. To enable this feature, set `
 As suggested in help message, to execute kubectl commands, send message in following format in the channel where BotKube is already added or as a direct message to BotKube.
 
 ```
-@BotKube <kubectl command without `kubectl` prefix> [--cluster-name <cluster_name>]
+@BotKube <kubectl command with or without `kubectl` prefix> [--cluster-name <cluster_name>]
 ```
+
+:::info
+You can also prefix your commands with `kubectl` , `kc` or `k`.
+:::
+
+:::caution
+In future, one of the kubectl prefix (`kubectl` , `kc` or `k`) will be required.
+:::
 
 ### Checking allowed commands
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- Adding information in Usage page about support kubectl prefix in commands. (Both on root and with prefix, e.g. @BotKube get po and @BotKube kubectl get po)

## Related issue(s)

https://github.com/kubeshop/botkube/issues/728

## Related PR
https://github.com/kubeshop/botkube/pull/752

## Preview
https://8899446b.botkube-docs-c3c.pages.dev/docs/next/usage/
