### PR TITLE
Document priv channels in Slack

### DIFF
--- a/docs/installation/socketslack/index.md
+++ b/docs/installation/socketslack/index.md
@@ -22,7 +22,6 @@ Follow the steps below to create and install BotKube Slack app to your Slack wor
 
    ![Select Workspace](assets/socketslack_select_workspace.png "Slack select workspace")
 
-
 1. Select **YAML** tab, copy & paste one of the following manifests, and click **Next**, and then **Create**.
 
 import Tabs from '@theme/Tabs';
@@ -32,92 +31,94 @@ import TabItem from '@theme/TabItem';
 <Tabs>
   <TabItem value="public" label="Public channels only" default>
 
-   ```yaml
-   display_information:
-     name: Botkube
-     description: Botkube
-     background_color: "#a653a6"
-   features:
-     bot_user:
-       display_name: Botkube
-       always_online: false
-   oauth_config:
-     scopes:
-       bot:
-         - channels:read
-         - app_mentions:read
-         - chat:write
-         - files:write
-   settings:
-     event_subscriptions:
-       bot_events:
-         - app_mention
-     interactivity:
-       is_enabled: true
-     org_deploy_enabled: false
-     socket_mode_enabled: true
-     token_rotation_enabled: false
-   ```
+```yaml
+display_information:
+  name: Botkube
+  description: Botkube
+  background_color: "#a653a6"
+features:
+  bot_user:
+    display_name: Botkube
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - channels:read
+      - app_mentions:read
+      - chat:write
+      - files:write
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false
+```
 
   </TabItem>
   <TabItem value="priv" label="Private channels only">
 
-   ```yaml
-   display_information:
-     name: Botkube
-     description: Botkube
-     background_color: "#a653a6"
-   features:
-     bot_user:
-       display_name: Botkube
-       always_online: false
-   oauth_config:
-     scopes:
-       bot:
-         - groups:read
-         - app_mentions:read
-         - chat:write
-         - files:write
-   settings:
-     event_subscriptions:
-       bot_events:
-         - app_mention
-     interactivity:
-       is_enabled: true
-     org_deploy_enabled: false
-     socket_mode_enabled: true
-     token_rotation_enabled: false
-   ```
+```yaml
+display_information:
+  name: Botkube
+  description: Botkube
+  background_color: "#a653a6"
+features:
+  bot_user:
+    display_name: Botkube
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - groups:read
+      - app_mentions:read
+      - chat:write
+      - files:write
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false
+```
+
   </TabItem>
   <TabItem value="public-priv" label="Public and private channels">
 
-   ```yaml
-   display_information:
-     name: Botkube
-     description: Botkube
-     background_color: "#a653a6"
-   features:
-     bot_user:
-       display_name: Botkube
-       always_online: false
-   oauth_config:
-     scopes:
-       bot:
-         - channels:read
-         - groups:read
-         - app_mentions:read
-         - chat:write
-         - files:write
-   settings:
-     event_subscriptions:
-       bot_events:
-         - app_mention
-     interactivity:
-       is_enabled: true
-     org_deploy_enabled: false
-     socket_mode_enabled: true
-     token_rotation_enabled: false
-   ```
+```yaml
+display_information:
+  name: Botkube
+  description: Botkube
+  background_color: "#a653a6"
+features:
+  bot_user:
+    display_name: Botkube
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - channels:read
+      - groups:read
+      - app_mentions:read
+      - chat:write
+      - files:write
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false
+```
+
   </TabItem>
 </Tabs>
 </div>

--- a/docs/installation/socketslack/index.md
+++ b/docs/installation/socketslack/index.md
@@ -22,7 +22,15 @@ Follow the steps below to create and install BotKube Slack app to your Slack wor
 
    ![Select Workspace](assets/socketslack_select_workspace.png "Slack select workspace")
 
-1. Select **YAML** tab, copy & paste following manifest, and click **Next**, and then **Create**.
+
+1. Select **YAML** tab, copy & paste one of the following manifests, and click **Next**, and then **Create**.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<div className="tab-container-nested">
+<Tabs>
+  <TabItem value="public" label="Public channels only" default>
 
    ```yaml
    display_information:
@@ -36,9 +44,9 @@ Follow the steps below to create and install BotKube Slack app to your Slack wor
    oauth_config:
      scopes:
        bot:
+         - channels:read
          - app_mentions:read
          - chat:write
-         - channels:read
          - files:write
    settings:
      event_subscriptions:
@@ -50,6 +58,69 @@ Follow the steps below to create and install BotKube Slack app to your Slack wor
      socket_mode_enabled: true
      token_rotation_enabled: false
    ```
+
+  </TabItem>
+  <TabItem value="priv" label="Private channels only">
+
+   ```yaml
+   display_information:
+     name: Botkube
+     description: Botkube
+     background_color: "#a653a6"
+   features:
+     bot_user:
+       display_name: Botkube
+       always_online: false
+   oauth_config:
+     scopes:
+       bot:
+         - groups:read
+         - app_mentions:read
+         - chat:write
+         - files:write
+   settings:
+     event_subscriptions:
+       bot_events:
+         - app_mention
+     interactivity:
+       is_enabled: true
+     org_deploy_enabled: false
+     socket_mode_enabled: true
+     token_rotation_enabled: false
+   ```
+  </TabItem>
+  <TabItem value="public-priv" label="Public and private channels">
+
+   ```yaml
+   display_information:
+     name: Botkube
+     description: Botkube
+     background_color: "#a653a6"
+   features:
+     bot_user:
+       display_name: Botkube
+       always_online: false
+   oauth_config:
+     scopes:
+       bot:
+         - channels:read
+         - groups:read
+         - app_mentions:read
+         - chat:write
+         - files:write
+   settings:
+     event_subscriptions:
+       bot_events:
+         - app_mention
+     interactivity:
+       is_enabled: true
+     org_deploy_enabled: false
+     socket_mode_enabled: true
+     token_rotation_enabled: false
+   ```
+  </TabItem>
+</Tabs>
+</div>
 
 ### Install BotKube to the Slack workspace
 

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -71,3 +71,9 @@
     background: #fff;
   }
 }
+
+/* Tabs in mdx */
+.tab-container-nested {
+	margin: 0 0 var(--ifm-list-margin);
+	padding-left: var(--ifm-list-left-padding);
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -74,6 +74,6 @@
 
 /* Tabs in mdx */
 .tab-container-nested {
-	margin: 0 0 var(--ifm-list-margin);
-	padding-left: var(--ifm-list-left-padding);
+  margin: 0 0 var(--ifm-list-margin);
+  padding-left: var(--ifm-list-left-padding);
 }

--- a/versioned_docs/version-0.14/installation/socketslack/index.md
+++ b/versioned_docs/version-0.14/installation/socketslack/index.md
@@ -22,7 +22,14 @@ Follow the steps below to create and install BotKube Slack app to your Slack wor
 
    ![Select Workspace](assets/socketslack_select_workspace.png "Slack select workspace")
 
-1. Select **YAML** tab, copy & paste following manifest, and click **Next**, and then **Create**.
+1. Select **YAML** tab, copy & paste one of the following manifests, and click **Next**, and then **Create**.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<div className="tab-container-nested">
+<Tabs>
+  <TabItem value="public" label="Public channels only" default>
 
    ```yaml
    display_information:
@@ -36,9 +43,9 @@ Follow the steps below to create and install BotKube Slack app to your Slack wor
    oauth_config:
      scopes:
        bot:
+         - channels:read
          - app_mentions:read
          - chat:write
-         - channels:read
          - files:write
    settings:
      event_subscriptions:
@@ -50,6 +57,69 @@ Follow the steps below to create and install BotKube Slack app to your Slack wor
      socket_mode_enabled: true
      token_rotation_enabled: false
    ```
+
+  </TabItem>
+  <TabItem value="priv" label="Private channels only">
+
+   ```yaml
+   display_information:
+     name: Botkube
+     description: Botkube
+     background_color: "#a653a6"
+   features:
+     bot_user:
+       display_name: Botkube
+       always_online: false
+   oauth_config:
+     scopes:
+       bot:
+         - groups:read
+         - app_mentions:read
+         - chat:write
+         - files:write
+   settings:
+     event_subscriptions:
+       bot_events:
+         - app_mention
+     interactivity:
+       is_enabled: true
+     org_deploy_enabled: false
+     socket_mode_enabled: true
+     token_rotation_enabled: false
+   ```
+  </TabItem>
+  <TabItem value="public-priv" label="Public and private channels">
+
+   ```yaml
+   display_information:
+     name: Botkube
+     description: Botkube
+     background_color: "#a653a6"
+   features:
+     bot_user:
+       display_name: Botkube
+       always_online: false
+   oauth_config:
+     scopes:
+       bot:
+         - channels:read
+         - groups:read
+         - app_mentions:read
+         - chat:write
+         - files:write
+   settings:
+     event_subscriptions:
+       bot_events:
+         - app_mention
+     interactivity:
+       is_enabled: true
+     org_deploy_enabled: false
+     socket_mode_enabled: true
+     token_rotation_enabled: false
+   ```
+  </TabItem>
+</Tabs>
+</div>
 
 ### Install BotKube to the Slack workspace
 

--- a/versioned_docs/version-0.14/installation/socketslack/index.md
+++ b/versioned_docs/version-0.14/installation/socketslack/index.md
@@ -31,92 +31,94 @@ import TabItem from '@theme/TabItem';
 <Tabs>
   <TabItem value="public" label="Public channels only" default>
 
-   ```yaml
-   display_information:
-     name: Botkube
-     description: Botkube
-     background_color: "#a653a6"
-   features:
-     bot_user:
-       display_name: Botkube
-       always_online: false
-   oauth_config:
-     scopes:
-       bot:
-         - channels:read
-         - app_mentions:read
-         - chat:write
-         - files:write
-   settings:
-     event_subscriptions:
-       bot_events:
-         - app_mention
-     interactivity:
-       is_enabled: true
-     org_deploy_enabled: false
-     socket_mode_enabled: true
-     token_rotation_enabled: false
-   ```
+```yaml
+display_information:
+  name: Botkube
+  description: Botkube
+  background_color: "#a653a6"
+features:
+  bot_user:
+    display_name: Botkube
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - channels:read
+      - app_mentions:read
+      - chat:write
+      - files:write
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false
+```
 
   </TabItem>
   <TabItem value="priv" label="Private channels only">
 
-   ```yaml
-   display_information:
-     name: Botkube
-     description: Botkube
-     background_color: "#a653a6"
-   features:
-     bot_user:
-       display_name: Botkube
-       always_online: false
-   oauth_config:
-     scopes:
-       bot:
-         - groups:read
-         - app_mentions:read
-         - chat:write
-         - files:write
-   settings:
-     event_subscriptions:
-       bot_events:
-         - app_mention
-     interactivity:
-       is_enabled: true
-     org_deploy_enabled: false
-     socket_mode_enabled: true
-     token_rotation_enabled: false
-   ```
+```yaml
+display_information:
+  name: Botkube
+  description: Botkube
+  background_color: "#a653a6"
+features:
+  bot_user:
+    display_name: Botkube
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - groups:read
+      - app_mentions:read
+      - chat:write
+      - files:write
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false
+```
+
   </TabItem>
   <TabItem value="public-priv" label="Public and private channels">
 
-   ```yaml
-   display_information:
-     name: Botkube
-     description: Botkube
-     background_color: "#a653a6"
-   features:
-     bot_user:
-       display_name: Botkube
-       always_online: false
-   oauth_config:
-     scopes:
-       bot:
-         - channels:read
-         - groups:read
-         - app_mentions:read
-         - chat:write
-         - files:write
-   settings:
-     event_subscriptions:
-       bot_events:
-         - app_mention
-     interactivity:
-       is_enabled: true
-     org_deploy_enabled: false
-     socket_mode_enabled: true
-     token_rotation_enabled: false
-   ```
+```yaml
+display_information:
+  name: Botkube
+  description: Botkube
+  background_color: "#a653a6"
+features:
+  bot_user:
+    display_name: Botkube
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - channels:read
+      - groups:read
+      - app_mentions:read
+      - chat:write
+      - files:write
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false
+```
+
   </TabItem>
 </Tabs>
 </div>


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- document usage of private Slack channels
- backport changes to 0.14


The diff is about `channels:read` for public and `groups:read` for priv, see: https://api.slack.com/methods/conversations.info

Preview URL: https://add-priv-channels.botkube-docs.pages.dev/