### PR TITLE
Deprecated support for typing commands without k|kc|kubectl prefix targeting version 0.15

### DIFF
--- a/docs/configuration/executor.md
+++ b/docs/configuration/executor.md
@@ -77,9 +77,9 @@ The default configuration for Helm chart can be found in the [values.yaml](https
 
 When executing a `kubectl` command, Botkube takes into account only bindings for a given execution Namespace. For example:
 
-- `@Botkube get po/botkube -n botkube` - collect `kubectl` executor bindings that include `botkube` or `*.` (all) Namespaces.
-- `@Botkube get po -A` - collect all `kubectl` executor bindings that include `*.` (all) Namespaces.
-- `@Botkube get po` - first, we resolve the execution Namespace. For that, we collect all enabled `kubectl` executor bindings and check the `defaultNamespace` property. If property is not define, we use the `default` Namespace. With resolved execution Namespace, we run the logic define in the first step.
+- `@Botkube kubectl get po/botkube -n botkube` - collect `kubectl` executor bindings that include `botkube` or `*.` (all) Namespaces.
+- `@Botkube kubectl get po -A` - collect all `kubectl` executor bindings that include `*.` (all) Namespaces.
+- `@Botkube kubectl get po` - first, we resolve the execution Namespace. For that, we collect all enabled `kubectl` executor bindings and check the `defaultNamespace` property. If property is not define, we use the `default` Namespace. With resolved execution Namespace, we run the logic define in the first step.
 
 For all collected `kubectl` executors, we merge properties with the following strategy:
 

--- a/docs/usage/executing-commands.md
+++ b/docs/usage/executing-commands.md
@@ -19,7 +19,7 @@ You can also prefix your commands with `kubectl` , `kc` or `k`.
 :::
 
 :::caution
-In future, one of the kubectl prefix (`kubectl` , `kc` or `k`) will be required.
+From version `0.17`, one of the kubectl prefixes (`kubectl` , `kc` or `k`) will always be required.
 :::
 
 This command needs to be executed from configured channel else use `--cluster-name` flag described in the [Specify cluster name](#specify-cluster-name) section.

--- a/versioned_docs/version-0.14/configuration/executor.md
+++ b/versioned_docs/version-0.14/configuration/executor.md
@@ -77,9 +77,9 @@ The default configuration for Helm chart can be found in the [values.yaml](https
 
 When executing a `kubectl` command, Botkube takes into account only bindings for a given execution Namespace. For example:
 
-- `@Botkube get po/botkube -n botkube` - collect `kubectl` executor bindings that include `botkube` or `*.` (all) Namespaces.
-- `@Botkube get po -A` - collect all `kubectl` executor bindings that include `*.` (all) Namespaces.
-- `@Botkube get po` - first, we resolve the execution Namespace. For that, we collect all enabled `kubectl` executor bindings and check the `defaultNamespace` property. If property is not define, we use the `default` Namespace. With resolved execution Namespace, we run the logic define in the first step.
+- `@Botkube kubectl get po/botkube -n botkube` - collect `kubectl` executor bindings that include `botkube` or `*.` (all) Namespaces.
+- `@Botkube kubectl get po -A` - collect all `kubectl` executor bindings that include `*.` (all) Namespaces.
+- `@Botkube kubectl get po` - first, we resolve the execution Namespace. For that, we collect all enabled `kubectl` executor bindings and check the `defaultNamespace` property. If property is not define, we use the `default` Namespace. With resolved execution Namespace, we run the logic define in the first step.
 
 For all collected `kubectl` executors, we merge properties with the following strategy:
 

--- a/versioned_docs/version-0.14/configuration/executor.md
+++ b/versioned_docs/version-0.14/configuration/executor.md
@@ -77,9 +77,9 @@ The default configuration for Helm chart can be found in the [values.yaml](https
 
 When executing a `kubectl` command, Botkube takes into account only bindings for a given execution Namespace. For example:
 
-- `@Botkube kubectl get po/botkube -n botkube` - collect `kubectl` executor bindings that include `botkube` or `*.` (all) Namespaces.
-- `@Botkube kubectl get po -A` - collect all `kubectl` executor bindings that include `*.` (all) Namespaces.
-- `@Botkube kubectl get po` - first, we resolve the execution Namespace. For that, we collect all enabled `kubectl` executor bindings and check the `defaultNamespace` property. If property is not define, we use the `default` Namespace. With resolved execution Namespace, we run the logic define in the first step.
+- `@Botkube get po/botkube -n botkube` - collect `kubectl` executor bindings that include `botkube` or `*.` (all) Namespaces.
+- `@Botkube get po -A` - collect all `kubectl` executor bindings that include `*.` (all) Namespaces.
+- `@Botkube get po` - first, we resolve the execution Namespace. For that, we collect all enabled `kubectl` executor bindings and check the `defaultNamespace` property. If property is not define, we use the `default` Namespace. With resolved execution Namespace, we run the logic define in the first step.
 
 For all collected `kubectl` executors, we merge properties with the following strategy:
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Adds required `kubectl` prefix to all examples.
E.g. changes documented commands from `@Botkube get po` to `@Botkube kubectl get po`.

The task was simplified after the latest updates to docs main.

## Related issue(s)

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->

See also https://github.com/kubeshop/botkube/issues/802