### PR TITLE
Fix relative redirect for old `socketslack` location

### DIFF
--- a/docs/installation/socketslack.mdx
+++ b/docs/installation/socketslack.mdx
@@ -5,10 +5,8 @@ sidebar_position: -1
 sidebar_class_name: hidden
 ---
 
-{/* This file simply redirects old "socketslack" route to the "slack" one, as we deprecated the legacy Slack integration. */}
+Redirecting to new docummentation... If you are not redirected, please click [here](./slack/index.md).
 
-import { Redirect } from "@docusaurus/router";
+import { RelativeRedirect } from "@site/src/components/RelativeRedirect";
 
-{" "}
-
-<Redirect to="./slack" />;
+<RelativeRedirect to="slack" />

--- a/docs/installation/socketslack.mdx
+++ b/docs/installation/socketslack.mdx
@@ -5,7 +5,7 @@ sidebar_position: -1
 sidebar_class_name: hidden
 ---
 
-Redirecting to new docummentation... If you are not redirected, please click [here](./slack/index.md).
+Redirecting to the new location of Slack installation... If you are not redirected in a few seconds, please click [here](./slack/index.md).
 
 import { RelativeRedirect } from "@site/src/components/RelativeRedirect";
 

--- a/src/components/RelativeRedirect/index.tsx
+++ b/src/components/RelativeRedirect/index.tsx
@@ -1,0 +1,17 @@
+import React, { FC } from "react";
+import { Redirect, useLocation } from "@docusaurus/router";
+
+export interface RelativeRedirectProps {
+  to: string;
+}
+
+export const RelativeRedirect: FC<RelativeRedirectProps> = ({ to }) => {
+  const { pathname } = useLocation();
+
+  let location = to;
+  if (pathname.endsWith("/")) {
+    location = `../${to}`;
+  }
+
+  return <Redirect to={location} />;
+};


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Fix relative redirect for old `socketslack` location

Unfortunately the redirect worked only without trailing `/`. 
Also, this page could be visible for users, so I changed the content to be more user-friendly.

This PR fixes these issues.

## Preview

Try both URLs

https://fix-redirect.botkube-docs-dcb.pages.dev/next/installation/socketslack/
https://fix-redirect.botkube-docs-dcb.pages.dev/next/installation/socketslack

## Related issue(s)

#178 