### PR TITLE
Add a multi-cluster warning for Socket Slack installation tutorial

### DIFF
--- a/docs/installation/slack/index.md
+++ b/docs/installation/slack/index.md
@@ -10,8 +10,13 @@ sidebar_position: 1
 
 ## Install Slack App in Your Slack workspace
 
-Botkube uses interactive messaging to provide better experience. Interactive messaging needs a Slack App with Socket Mode enabled
-and currently this is not suitable for Slack App Directory listing. For this reason, you need to create a Slack App in your own Slack workspace and use it for Botkube deployment.
+Botkube uses interactive messaging to provide better experience. Interactive messaging needs a Slack App with Socket Mode enabled and currently this is not suitable for Slack App Directory listing. For this reason, you need to create a Slack App in your own Slack workspace and use it for Botkube deployment.
+
+:::warning
+**Multi-cluster caveat:** The architecture of socket-based Slack apps is different from the older Slack app. If you would like to use [Botkube executors](../../configuration/executor/index.md) (e.g. kubectl commands) and have multiple Kubernetes clusters, you need to create and install a Botkube Slack app for each cluster. This is required so that the Slack to Botkube connections go to the right place. We recommend you set the name of each app to reflect the cluster it will connect to in the next steps.
+
+To learn more about the Slack Socket API limitation, see the [comment](https://github.com/slackapi/bolt-js/issues/1263#issuecomment-1006372826) in the official Slack bot framework repository.
+:::
 
 Follow the steps below to create and install Botkube Slack app to your Slack workspace.
 

--- a/versioned_docs/version-0.14/installation/socketslack/index.md
+++ b/versioned_docs/version-0.14/installation/socketslack/index.md
@@ -9,6 +9,12 @@ sidebar_position: 1
 Botkube uses interactive messaging to provide better experience. Interactive messaging needs a Slack App with Socket Mode enabled
 and currently this is not suitable for Slack App Directory listing. For this reason, you need to create a Slack App in your own Slack workspace and use it for Botkube deployment.
 
+:::warning
+**Multi-cluster caveat:** The architecture of socket-based Slack apps is different from the older Slack app. If you would like to use [Botkube executors](../../configuration/executor.md) (e.g. kubectl commands) and have multiple Kubernetes clusters, you need to create and install a Botkube Slack app for each cluster. This is required so that the Slack to Botkube connections go to the right place. We recommend you set the name of each app to reflect the cluster it will connect to in the next steps.
+
+To learn more about the Slack Socket API limitation, see the [comment](https://github.com/slackapi/bolt-js/issues/1263#issuecomment-1006372826) in the official Slack bot framework repository.
+:::
+
 Follow the steps below to create and install Botkube Slack app to your Slack workspace.
 
 ### Create Slack app

--- a/versioned_docs/version-0.15/installation/socketslack/index.md
+++ b/versioned_docs/version-0.15/installation/socketslack/index.md
@@ -9,6 +9,12 @@ sidebar_position: 1
 Botkube uses interactive messaging to provide better experience. Interactive messaging needs a Slack App with Socket Mode enabled
 and currently this is not suitable for Slack App Directory listing. For this reason, you need to create a Slack App in your own Slack workspace and use it for Botkube deployment.
 
+:::warning
+**Multi-cluster caveat:** The architecture of socket-based Slack apps is different from the older Slack app. If you would like to use [Botkube executors](../../configuration/executor.md) (e.g. kubectl commands) and have multiple Kubernetes clusters, you need to create and install a Botkube Slack app for each cluster. This is required so that the Slack to Botkube connections go to the right place. We recommend you set the name of each app to reflect the cluster it will connect to in the next steps.
+
+To learn more about the Slack Socket API limitation, see the [comment](https://github.com/slackapi/bolt-js/issues/1263#issuecomment-1006372826) in the official Slack bot framework repository.
+:::
+
 Follow the steps below to create and install Botkube Slack app to your Slack workspace.
 
 ### Create Slack app

--- a/versioned_docs/version-0.16/installation/slack/index.md
+++ b/versioned_docs/version-0.16/installation/slack/index.md
@@ -13,6 +13,12 @@ sidebar_position: 1
 Botkube uses interactive messaging to provide better experience. Interactive messaging needs a Slack App with Socket Mode enabled
 and currently this is not suitable for Slack App Directory listing. For this reason, you need to create a Slack App in your own Slack workspace and use it for Botkube deployment.
 
+:::warning
+**Multi-cluster caveat:** The architecture of socket-based Slack apps is different from the older Slack app. If you would like to use [Botkube executors](../../configuration/executor.md) (e.g. kubectl commands) and have multiple Kubernetes clusters, you need to create and install a Botkube Slack app for each cluster. This is required so that the Slack to Botkube connections go to the right place. We recommend you set the name of each app to reflect the cluster it will connect to in the next steps.
+
+To learn more about the Slack Socket API limitation, see the [comment](https://github.com/slackapi/bolt-js/issues/1263#issuecomment-1006372826) in the official Slack bot framework repository.
+:::
+
 Follow the steps below to create and install Botkube Slack app to your Slack workspace.
 
 ### Create Slack app

--- a/versioned_docs/version-0.17/installation/slack/index.md
+++ b/versioned_docs/version-0.17/installation/slack/index.md
@@ -13,6 +13,12 @@ sidebar_position: 1
 Botkube uses interactive messaging to provide better experience. Interactive messaging needs a Slack App with Socket Mode enabled
 and currently this is not suitable for Slack App Directory listing. For this reason, you need to create a Slack App in your own Slack workspace and use it for Botkube deployment.
 
+:::warning
+**Multi-cluster caveat:** The architecture of socket-based Slack apps is different from the older Slack app. If you would like to use [Botkube executors](../../configuration/executor/index.md) (e.g. kubectl commands) and have multiple Kubernetes clusters, you need to create and install a Botkube Slack app for each cluster. This is required so that the Slack to Botkube connections go to the right place. We recommend you set the name of each app to reflect the cluster it will connect to in the next steps.
+
+To learn more about the Slack Socket API limitation, see the [comment](https://github.com/slackapi/bolt-js/issues/1263#issuecomment-1006372826) in the official Slack bot framework repository.
+:::
+
 Follow the steps below to create and install Botkube Slack app to your Slack workspace.
 
 ### Create Slack app


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add a multi-cluster warning for Socket Slack installation tutorial

There were a few different cases where users were confused around the multi-cluster usage with Socket Slack integration. This PR makes it a bit clearer what are the limittions of the Slack app.

## Preview

https://slack-multi-cluster.botkube-docs-dcb.pages.dev/installation/slack/