### PR TITLE
Add info about setting up GitHub Pages and initial GitHub job

### DIFF
--- a/docs/plugin/quick-start.md
+++ b/docs/plugin/quick-start.md
@@ -29,4 +29,11 @@ and two example release jobs:
    - GitHub releases, defined at `.github/workflows/release.yml` in your GitHub repository.
    - GitHub Pages, defined at `.github/workflows/pages-release.yml` in your GitHub repository.
 
+   If you pick the GitHub Pages, a further configuration is needed:
+
+   1. In project settings, enable [publishing GitHub Pages via GitHub Action](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow).
+   2. Adjust the `github-pages` deployment environment. You can either:
+      - remove the deployment environment if you don't need any protection rules
+      - add an environment protection rule so that you can deploy pages on each new tag. If you use tagging like `vX.Y.Z`, you can add the `v*` rule. As an alternative, can select **All branches** from the dropdown.
+
 4. Update the README.md file to describe the plugins that you created.

--- a/docs/plugin/quick-start.md
+++ b/docs/plugin/quick-start.md
@@ -24,7 +24,19 @@ and two example release jobs:
 
    This creates your own plugin repository with a single commit.
 
-3. Decide which release job you prefer, the GitHub releases, or GitHub pages. Once decided, remove one the above workflow in your new repository:
+3. After a few seconds, the `.github/workflows/setup.yml` job will create a new commit. This job removes Kubeshop related files, such as:
+
+   - `CONTRIBUTING.md`
+   - `CODE_OF_CONDUCT.md`
+   - `LICENSE`
+   - `SECURITY.md`
+   - `.github/CODEOWNERS`
+
+   Additionally, it updates links in README.md to point to your own repository instead of Kubeshop's one. In case of job failure, you need to make and commit those changes manually.
+
+   This job runs only once, later you can remove it or disable it.
+
+4. Decide which release job you prefer, the GitHub releases, or GitHub pages. Once decided, remove one the above workflow in your new repository:
 
    - GitHub releases, defined at `.github/workflows/release.yml` in your GitHub repository.
    - GitHub Pages, defined at `.github/workflows/pages-release.yml` in your GitHub repository.
@@ -36,4 +48,4 @@ and two example release jobs:
       - remove the deployment environment if you don't need any protection rules
       - add an environment protection rule so that you can deploy pages on each new tag. If you use tagging like `vX.Y.Z`, you can add the `v*` rule. As an alternative, can select **All branches** from the dropdown.
 
-4. Update the README.md file to describe the plugins that you created.
+5. Add LICENSE file and update the README.md file to describe the plugins that you created.

--- a/versioned_docs/version-0.17/plugin/quick-start.md
+++ b/versioned_docs/version-0.17/plugin/quick-start.md
@@ -29,4 +29,11 @@ and two example release jobs:
    - GitHub releases, defined at `.github/workflows/release.yml` in your GitHub repository.
    - GitHub Pages, defined at `.github/workflows/pages-release.yml` in your GitHub repository.
 
+   If you pick the GitHub Pages, a further configuration is needed:
+
+   1. In project settings, enable [publishing GitHub Pages via GitHub Action](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow).
+   2. Adjust the `github-pages` deployment environment. You can either:
+      - remove the deployment environment if you don't need any protection rules
+      - add an environment protection rule so that you can deploy pages on each new tag. If you use tagging like `vX.Y.Z`, you can add the `v*` rule. As an alternative, can select **All branches** from the dropdown.
+
 4. Update the README.md file to describe the plugins that you created.

--- a/versioned_docs/version-0.17/plugin/quick-start.md
+++ b/versioned_docs/version-0.17/plugin/quick-start.md
@@ -24,7 +24,19 @@ and two example release jobs:
 
    This creates your own plugin repository with a single commit.
 
-3. Decide which release job you prefer, the GitHub releases, or GitHub pages. Once decided, remove one the above workflow in your new repository:
+3. After a few seconds, the `.github/workflows/setup.yml` job will create a new commit. This job removes Kubeshop related files, such as:
+
+   - `CONTRIBUTING.md`
+   - `CODE_OF_CONDUCT.md`
+   - `LICENSE`
+   - `SECURITY.md`
+   - `.github/CODEOWNERS`
+
+   Additionally, it updates links in README.md to point to your own repository instead of Kubeshop's one. In case of job failure, you need to make and commit those changes manually.
+
+   This job runs only once, later you can remove it or disable it.
+
+4. Decide which release job you prefer, the GitHub releases, or GitHub pages. Once decided, remove one the above workflow in your new repository:
 
    - GitHub releases, defined at `.github/workflows/release.yml` in your GitHub repository.
    - GitHub Pages, defined at `.github/workflows/pages-release.yml` in your GitHub repository.
@@ -36,4 +48,4 @@ and two example release jobs:
       - remove the deployment environment if you don't need any protection rules
       - add an environment protection rule so that you can deploy pages on each new tag. If you use tagging like `vX.Y.Z`, you can add the `v*` rule. As an alternative, can select **All branches** from the dropdown.
 
-4. Update the README.md file to describe the plugins that you created.
+5. Add LICENSE file and update the README.md file to describe the plugins that you created.


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add info about setting up GitHub Pages
- Backport to 0.17


Preview URL: https://add-gh-info.botkube-docs.pages.dev/plugin/quick-start

## Related issue(s)

Fix https://github.com/kubeshop/botkube-plugins-template/issues/8 
Fix https://github.com/kubeshop/botkube-plugins-template/issues/6