### PR TITLE
Removed outdated `notification.type` mentions

### DIFF
--- a/docs/configuration/communication/index.md
+++ b/docs/configuration/communication/index.md
@@ -8,6 +8,7 @@ The communication settings contains:
 
 - Configuration for communication platforms scoped in separate communication groups,
 - Platform-specific options, such as multi-channel configuration for platforms that support channels.
+
 ## Communication groups
 
 Communication group is a way to aggregate separate configurations for a set of communication platforms. You can specify multiple communication groups, and, in a result, support multiple Slack or Mattermost workspaces, Discord servers, or Elasticsearch server instances.
@@ -152,7 +153,7 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-   
+
     # Settings for MS Teams.
     teams:
       # If true, enables MS Teams bot.
@@ -201,7 +202,7 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-      
+
     # Settings for Elasticsearch.
     elasticsearch:
       # If true, enables Elasticsearch.

--- a/docs/configuration/communication/index.md
+++ b/docs/configuration/communication/index.md
@@ -7,8 +7,7 @@ sidebar_position: 1
 The communication settings contains:
 
 - Configuration for communication platforms scoped in separate communication groups,
-- Platform-specific options, such as multi-channel configuration for platforms that support channels, or option to toggle notification type to short or long.
-
+- Platform-specific options, such as multi-channel configuration for platforms that support channels.
 ## Communication groups
 
 Communication group is a way to aggregate separate configurations for a set of communication platforms. You can specify multiple communication groups, and, in a result, support multiple Slack or Mattermost workspaces, Discord servers, or Elasticsearch server instances.
@@ -122,9 +121,7 @@ communications:
               - k8s-events
       # Slack token.
       token: "SLACK_API_TOKEN"
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
+
 
     # Settings for Mattermost.
     mattermost:
@@ -156,9 +153,7 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
+      
 
     # Settings for MS Teams.
     teams:
@@ -180,8 +175,6 @@ communications:
       # The path in endpoint URL provided while registering Botkube to MS Teams.
       messagePath: "/bots/teams"
       notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
       # The Service port for bot endpoint on Botkube container.
       port: 3978
 
@@ -211,9 +204,7 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
+      
 
     # Settings for Elasticsearch.
     elasticsearch:

--- a/docs/configuration/communication/index.md
+++ b/docs/configuration/communication/index.md
@@ -122,7 +122,6 @@ communications:
       # Slack token.
       token: "SLACK_API_TOKEN"
 
-
     # Settings for Mattermost.
     mattermost:
       # If true, enables Mattermost bot.
@@ -153,8 +152,7 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-      
-
+   
     # Settings for MS Teams.
     teams:
       # If true, enables MS Teams bot.
@@ -205,7 +203,6 @@ communications:
             sources:
               - k8s-events
       
-
     # Settings for Elasticsearch.
     elasticsearch:
       # If true, enables Elasticsearch.

--- a/docs/configuration/communication/index.md
+++ b/docs/configuration/communication/index.md
@@ -172,7 +172,6 @@ communications:
           - k8s-events
       # The path in endpoint URL provided while registering Botkube to MS Teams.
       messagePath: "/bots/teams"
-      notification:
       # The Service port for bot endpoint on Botkube container.
       port: 3978
 

--- a/versioned_docs/version-1.0/configuration/communication/index.md
+++ b/versioned_docs/version-1.0/configuration/communication/index.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 The communication settings contains:
 
 - Configuration for communication platforms scoped in separate communication groups,
-- Platform-specific options, such as multi-channel configuration for platforms that support channels, or option to toggle notification type to short or long.
+- Platform-specific options, such as multi-channel configuration for platforms that support channels.
 
 ## Communication groups
 
@@ -122,9 +122,6 @@ communications:
               - k8s-events
       # Slack token.
       token: "SLACK_API_TOKEN"
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
 
     # Settings for Mattermost.
     mattermost:
@@ -156,9 +153,6 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
 
     # Settings for MS Teams.
     teams:
@@ -179,9 +173,6 @@ communications:
           - k8s-events
       # The path in endpoint URL provided while registering Botkube to MS Teams.
       messagePath: "/bots/teams"
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
       # The Service port for bot endpoint on Botkube container.
       port: 3978
 
@@ -211,9 +202,6 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
 
     # Settings for Elasticsearch.
     elasticsearch:

--- a/versioned_docs/version-1.1/configuration/communication/index.md
+++ b/versioned_docs/version-1.1/configuration/communication/index.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 The communication settings contains:
 
 - Configuration for communication platforms scoped in separate communication groups,
-- Platform-specific options, such as multi-channel configuration for platforms that support channels, or option to toggle notification type to short or long.
+- Platform-specific options, such as multi-channel configuration for platforms that support channels.
 
 ## Communication groups
 
@@ -122,9 +122,6 @@ communications:
               - k8s-events
       # Slack token.
       token: "SLACK_API_TOKEN"
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
 
     # Settings for Mattermost.
     mattermost:
@@ -156,9 +153,6 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
 
     # Settings for MS Teams.
     teams:
@@ -179,9 +173,6 @@ communications:
           - k8s-events
       # The path in endpoint URL provided while registering Botkube to MS Teams.
       messagePath: "/bots/teams"
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
       # The Service port for bot endpoint on Botkube container.
       port: 3978
 
@@ -211,9 +202,6 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
 
     # Settings for Elasticsearch.
     elasticsearch:

--- a/versioned_docs/version-1.2/configuration/communication/index.md
+++ b/versioned_docs/version-1.2/configuration/communication/index.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 The communication settings contains:
 
 - Configuration for communication platforms scoped in separate communication groups,
-- Platform-specific options, such as multi-channel configuration for platforms that support channels, or option to toggle notification type to short or long.
+- Platform-specific options, such as multi-channel configuration for platforms that support channels.
 
 ## Communication groups
 
@@ -122,9 +122,6 @@ communications:
               - k8s-events
       # Slack token.
       token: "SLACK_API_TOKEN"
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
 
     # Settings for Mattermost.
     mattermost:
@@ -156,9 +153,6 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
 
     # Settings for MS Teams.
     teams:
@@ -179,9 +173,6 @@ communications:
           - k8s-events
       # The path in endpoint URL provided while registering Botkube to MS Teams.
       messagePath: "/bots/teams"
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
       # The Service port for bot endpoint on Botkube container.
       port: 3978
 
@@ -211,9 +202,6 @@ communications:
             # Notification sources configuration for a given channel.
             sources:
               - k8s-events
-      notification:
-        # Configures notification type that are sent. Possible values: `short`, `long`.
-        type: short
 
     # Settings for Elasticsearch.
     elasticsearch:


### PR DESCRIPTION
Removed outdated configuration of  `notification.type` which was deprecated in v1.0.0 from documentation

![image](https://github.com/kubeshop/botkube-docs/assets/100558220/fa04fb57-13af-4dfd-971f-1a3a74ce0b60)

Resolves #260 